### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -37,7 +37,7 @@
         <poi.version>3.9</poi.version>
         <jasper.version>5.0.1</jasper.version>
         <commons.digester.version>2.1</commons.digester.version>
-        <commons.collections.version>3.2.1</commons.collections.version>
+        <commons.collections.version>3.2.2</commons.collections.version>
         <guava.version>16.0.1</guava.version>
         <itex.version>2.1.7</itex.version>
         <itextpdf.version>5.4.2</itextpdf.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability